### PR TITLE
Remove dead links, fix Slack Invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,11 @@
         </table>
 
 
-<p> Interested in Delivering a Session? Then get please fill in this <a href="http://speakersub.get-psuguk.org">Speakers Submission form</a></p>
-<p> Please fill in our short Speaker feedback survey <a href="http://feedback.get-psuguk.org">Speaker Feedback form</a></p>
-<p> If you have a suggestion for a topic please let us know via this <a href="http://topic.get-psuguk.org">Topic Suggestion form</a></p>
+<p> Interested in Delivering a Session? Then get please get in touch via Slack</p>
+<p> Please give Speaker feedback via Slack</p>
+<p> If you have a suggestion for a topic please let us know via Slack</p>
 
-<p>We also have a Slack team for general PowerShell Chatter - If you want to be invited please drop your email in the bow below </p>
-    <iframe src="https://get-psuguk.herokuapp.com/" frameBorder="0" scrolling="no" height="350" width="400" align="center"></iframe> 
+<p>We also have a Slack team for general PowerShell Chatter - <a href="https://slofile.com/slack/get-psuguk">request an invite</a></p>
       <footer class="site-footer" >
 
         


### PR DESCRIPTION
Domain has expired, by the looks of it, so none of the links are working.
Slack invite Heroku app also appears to be malfunctioning.
Found "proper" updated link for Slack (meetup comment) and redirected everything there...